### PR TITLE
Devices: fsl: mf0300_6dq: disable ALSA audio HAL

### DIFF
--- a/mf0300_6dq/BoardConfig.mk
+++ b/mf0300_6dq/BoardConfig.mk
@@ -62,6 +62,7 @@ PHONE_MODULE_INCLUDE := true
 # camera hal v3
 IMX_CAMERA_HAL_V3 := true
 
+BOARD_USES_ALSA_AUDIO := false
 
 #define consumer IR HAL support
 IMX6_CONSUMER_IR_HAL := false


### PR DESCRIPTION
To avoid logcat noise like:

W audio_hw_primary: rate 44100, channel 2 period_size 0xc0
E audio_hw_primary: cannot open pcm_out driver 0: cannot open device /dev/snd/pcmC4294967295D0p: No such file or directory
I audio_hw_primary: start_output_stream_primary... -1351442432, device 2
W audio_hw_primary: card -1, port 0 device 0x2
W audio_hw_primary: rate 44100, channel 2 period_size 0xc0

Because we have no audio device (sound card) available.