### PR TITLE
Device: fsl: mf0300_6dq: store Shift4 cert as pem key in /etc

### DIFF
--- a/mf0300_6dq/imx6_mf0300.mk
+++ b/mf0300_6dq/imx6_mf0300.mk
@@ -289,6 +289,7 @@ PRODUCT_PACKAGES += \
     libfsldisplay
 
 PRODUCT_COPY_FILES +=	\
+	device/fsl/mf0300_6dq/security/shift4.x509.pem:system/etc/security/shift4.x509.pem \
 	device/fsl/common/input/Dell_Dell_USB_Keyboard.kl:system/usr/keylayout/Dell_Dell_USB_Keyboard.kl \
 	device/fsl/common/input/Dell_Dell_USB_Keyboard.idc:system/usr/idc/Dell_Dell_USB_Keyboard.idc \
 	device/fsl/common/input/Dell_Dell_USB_Entry_Keyboard.idc:system/usr/idc/Dell_Dell_USB_Entry_Keyboard.idc \


### PR DESCRIPTION
Copy certificate to /etc/security/shift4.x509.pem for PackageInstaller package
to verify every apk installation.