### PR TITLE
Devices: fsl: mf0300_6dq: selinux define ttymxc4 as cardreader device

### DIFF
--- a/mf0300_6dq/sepolicy/device.te
+++ b/mf0300_6dq/sepolicy/device.te
@@ -1,1 +1,2 @@
 type bluetooth_device, dev_type;
+type cardreader_device, dev_type;

--- a/mf0300_6dq/sepolicy/file_contexts
+++ b/mf0300_6dq/sepolicy/file_contexts
@@ -26,6 +26,7 @@
 /dev/ttyUSB[0-9]*               u:object_r:tty_device:s0
 /dev/sda[0-8]*                  u:object_r:fuse:s0
 /dev/ttymxc1                    u:object_r:bluetooth_device:s0
+/dev/ttymxc4                    u:object_r:cardreader_device:s0
 
 #bcm-bt rfkill
 /sys/class/rfkill/rfkill0/state u:object_r:sysfs_bluetooth_writable:s0


### PR DESCRIPTION
Sepolicy: define new device as in file_contexts