### PR TITLE
Devices: fsl: mf0300_6dq: define sepolicy use_cardreader macros

### DIFF
--- a/mf0300_6dq/sepolicy/te_macros
+++ b/mf0300_6dq/sepolicy/te_macros
@@ -17,3 +17,10 @@ define(`use_serialnumberservice', `
   allow $1 serialnumber_socket:sock_file { getattr read write };
   allow $1 sernd:unix_stream_socket { getattr getopt read write connectto };
 ')
+
+###########################################
+# use_cardreader(domain)
+# Ability to read from cardreader_device
+define(`use_cardreader', `
+  allow $1 cardreader_device:chr_file { open getattr read write ioctl };
+')


### PR DESCRIPTION
Allow domains to use cardreader_device via use_cardreader() macros.

Usage example:
use_cardreader(platform_app)