### PR TITLE
disable access point settings and multi-user support

### DIFF
--- a/mf0300_6dq/mf0300_6dq.mk
+++ b/mf0300_6dq/mf0300_6dq.mk
@@ -144,4 +144,5 @@ PRODUCT_PACKAGES += \
 	TeamViewerQS
 
 PRODUCT_PROPERTY_OVERRIDES += \
+    ro.tether.denied=true \
     ro.internel.storage_size=/sys/block/bootdev_size

--- a/mf0300_6dq/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/mf0300_6dq/overlay/frameworks/base/core/res/res/values/config.xml
@@ -71,9 +71,9 @@
     <integer name="config_screenBrightnessDim">5</integer>
 
     <!--  Maximum number of supported users -->
-    <integer name="config_multiuserMaximumUsers">8</integer>
+    <integer name="config_multiuserMaximumUsers">1</integer>
     <!--  Whether Multiuser UI should be shown -->
-    <bool name="config_enableMultiUserUI">true</bool>
+    <bool name="config_enableMultiUserUI">false</bool>
 
     <!-- Whether a software navigation bar should be shown. NOTE: in the future this may be
          autodetected from the Configuration. -->


### PR DESCRIPTION
- disabled access point setting property `ro.tether.denied=true`
- disabled [multi-user support](https://source.android.com/devices/tech/admin/multi-user#applying_the_overlay)