### PR TITLE
Devices: fsl: mf0300_6dq: allow system_server to write timerslack_ns

### DIFF
--- a/mf0300_6dq/sepolicy/system_server.te
+++ b/mf0300_6dq/sepolicy/system_server.te
@@ -1,1 +1,4 @@
 allow system_server shift4_app:file w_file_perms;
+
+# Allow system_server to write to /proc/<pid>/timerslack_ns
+allow system_server appdomain:file w_file_perms;


### PR DESCRIPTION
Allow system_server to write to /proc/<pid>/timerslack_ns.
The timerslack_ns denials spam the system really horribly:

type=1400 audit(42.050:9): avc: denied { write } for pid=419 comm="Binder:419_4" name="timerslack_ns" dev="proc" ino=16619 scontext=u:r:system_server:s0 tcontext=u:r:untrusted_app_25:s0:c512,c768 tclass=file permissive=0