### PR TITLE
Devices: fsl: mf0300_6dq: selinux define ttymxc3 as console device

### DIFF
--- a/mf0300_6dq/sepolicy/file_contexts
+++ b/mf0300_6dq/sepolicy/file_contexts
@@ -26,6 +26,7 @@
 /dev/ttyUSB[0-9]*               u:object_r:tty_device:s0
 /dev/sda[0-8]*                  u:object_r:fuse:s0
 /dev/ttymxc1                    u:object_r:bluetooth_device:s0
+/dev/ttymxc3                    u:object_r:console_device:s0
 /dev/ttymxc4                    u:object_r:cardreader_device:s0
 
 #bcm-bt rfkill


### PR DESCRIPTION
Sepolicy: define new device as in file_contexts in order to apply console_device seplicies to the
ttymxc3 device, because the act of granting "init to get access to ttymxc3" spam the system really horribly:

type=1400 audit(16.110:7): avc: granted { read open } for pid=299 comm="init" path="/dev/ttymxc3" dev="tmpfs" ino=10483 scontext=u:r:init:s0 tcontext=u:object_r:tty_device:s0 tclass=chr_file