### PR TITLE
Devices: fsl: mf0300_6dq: selinux define graphics devices

### DIFF
--- a/mf0300_6dq/sepolicy/file_contexts
+++ b/mf0300_6dq/sepolicy/file_contexts
@@ -28,6 +28,8 @@
 /dev/ttymxc1                    u:object_r:bluetooth_device:s0
 /dev/ttymxc3                    u:object_r:console_device:s0
 /dev/ttymxc4                    u:object_r:cardreader_device:s0
+/dev/dri                        u:object_r:graphics_device:s0
+/dev/dri/card0                  u:object_r:graphics_device:s0
 
 #bcm-bt rfkill
 /sys/class/rfkill/rfkill0/state u:object_r:sysfs_bluetooth_writable:s0


### PR DESCRIPTION
In order to apply proper selinux policies and remove audit selinux log messages:
type=1400 audit(17.450:8): avc: denied { read } for pid=297 comm="surfaceflinger" name="dri" dev="tmpfs" ino=10442 scontext=u:r:surfaceflinger:s0 tcontext=u:object_r:device:s0 tclass=dir permissive=0
type=1400 audit(17.320:4): avc: denied { read } for pid=296 comm="surfaceflinger" name="dri" dev="tmpfs" ino=9298 scontext=u:r:surfaceflinger:s0 tcontext=u:object_r:device:s0 tclass=dir permissive=0