### PR TITLE
Devices: fsl: mf0300_6dq: allow platform_app to stat rootfs

### DIFF
--- a/mf0300_6dq/sepolicy/platform_app.te
+++ b/mf0300_6dq/sepolicy/platform_app.te
@@ -1,0 +1,1 @@
+allow platform_app rootfs:dir r_dir_perms;


### PR DESCRIPTION
Granting SystemUI app platform_app to get access to rootfs:

type=1400 audit(1546079070.984:22): avc: denied { getattr } for pid=565 comm=496E666C6174657254687265616420 path="/" dev="rootfs" ino=1 scontext=u:r:platform_app:s0:c512,c768 tcontext=u:object_r:rootfs:s0 tclass=dir