### PR TITLE
Devices: fsl: mf0300_6dq: allow Shift4 apps to use system services

### DIFF
--- a/mf0300_6dq/sepolicy/shift4_app.te
+++ b/mf0300_6dq/sepolicy/shift4_app.te
@@ -14,3 +14,23 @@ use_cardreader(shift4_app)
 
 allow shift4_app shift4_app_data_file:dir create_dir_perms;
 allow shift4_app shift4_app_data_file: { file lnk_file } create_file_perms;
+
+allow shift4_app { accessibility_service
+                   activity_service
+                   appops_service
+                   audio_service
+                   autofill_service
+                   connectivity_service
+                   content_service
+                   display_service
+                   graphicsstats_service
+                   input_method_service
+                   input_service
+                   jobscheduler_service
+                   mount_service
+                   notification_service
+                   power_service
+                   surfaceflinger_service
+                   uimode_service
+                   usb_service
+                   wifi_service }:service_manager find;


### PR DESCRIPTION
Echo-POS Shift4 app uses a lot of system services through service manager.