### PR TITLE
Devices: fsl: mf0300_6dq: fix user build

### DIFF
--- a/mf0300_6dq/sepolicy/te_macros
+++ b/mf0300_6dq/sepolicy/te_macros
@@ -1,6 +1,3 @@
-# enable for user build
-define(`userdebug_or_eng', ifelse(target_build_variant, `eng', $1, ifelse(target_build_variant, `userdebug', $1, ifelse(target_build_variant, `user', $1))))
-
 # define new macroses for easy use
 ###########################################
 # use_bluetooth(domain)


### PR DESCRIPTION
Because permissive domains are not allowed in user builds (su package in this case)