### PR TITLE
Devices: fsl: mf0300_6dq: disable bluetooth PBAP support

### DIFF
--- a/mf0300_6dq/overlay/packages/apps/Bluetooth/res/values/config.xml
+++ b/mf0300_6dq/overlay/packages/apps/Bluetooth/res/values/config.xml
@@ -14,4 +14,6 @@
  -->
  <resources>
      <bool name="profile_supported_avrcp_controller">true</bool>
+     <bool name="profile_supported_pbap">false</bool>
+     <bool name="profile_supported_pbapclient">false</bool>
  </resources>


### PR DESCRIPTION
Because it is not supported and due to Contacts and ContactsProvider
removing leads to Bluetooth crash while starting