### PR TITLE
Devices: fsl: mf0300_6dq: remove ubi packages

### DIFF
--- a/mf0300_6dq/imx6_mf0300.mk
+++ b/mf0300_6dq/imx6_mf0300.mk
@@ -239,8 +239,6 @@ omx_excluded_libs :=					\
 
 PRODUCT_PACKAGES += $(omx_libs) $(omx_excluded_libs)
 
-PRODUCT_PACKAGES += libubi ubinize ubiformat ubiattach ubidetach ubiupdatevol ubimkvol ubinfo mkfs_ubifs 
-
 # FUSE based emulated sdcard daemon
 PRODUCT_PACKAGES += sdcard
 


### PR DESCRIPTION
Because mf0300_6dq does not support Unsorted Block Images