### PR TITLE
Devices: fsl: mf0300_6dq: use separated ota config for every build

### DIFF
--- a/mf0300_6dq/etc/ota-eng.conf
+++ b/mf0300_6dq/etc/ota-eng.conf
@@ -1,0 +1,3 @@
+server=10.192.224.178
+port=10888
+ota_folder_suffix=oreo

--- a/mf0300_6dq/etc/ota-user.conf
+++ b/mf0300_6dq/etc/ota-user.conf
@@ -1,0 +1,3 @@
+server=10.192.224.178
+port=10888
+ota_folder_suffix=oreo

--- a/mf0300_6dq/etc/ota-userdebug.conf
+++ b/mf0300_6dq/etc/ota-userdebug.conf
@@ -1,0 +1,3 @@
+server=10.192.224.178
+port=10888
+ota_folder_suffix=oreo

--- a/mf0300_6dq/imx6_mf0300.mk
+++ b/mf0300_6dq/imx6_mf0300.mk
@@ -289,7 +289,7 @@ PRODUCT_COPY_FILES +=	\
 	device/fsl/common/input/eGalax_Touch_Screen.idc:system/usr/idc/Novatek_NT11003_Touch_Screen.idc \
 	system/core/rootdir/init.rc:root/init.rc \
 	device/fsl/imx6/etc/init.usb.rc:root/init.freescale.usb.rc \
-	device/fsl/imx6/etc/ota.conf:system/etc/ota.conf \
+	device/fsl/mf0300_6dq/etc/ota-$(TARGET_BUILD_VARIANT).conf:system/etc/ota.conf \
         device/fsl/imx6/init.recovery.freescale.rc:root/init.recovery.freescale.rc \
     $(FSL_PROPRIETARY_PATH)/fsl-proprietary/media-profile/media_codecs_google_audio.xml:system/etc/media_codecs_google_audio.xml \
     $(FSL_PROPRIETARY_PATH)/fsl-proprietary/media-profile/media_codecs_google_video.xml:system/etc/media_codecs_google_video.xml \


### PR DESCRIPTION
Files:
    mf0300/etc/ota-eng.conf
    mf0300/etc/ota-user.conf
    mf0300/etc/ota-userdebug.conf

are complitely copied from file imx6/etc/ota.conf without any changes.