### PR TITLE
Devices: fsl: mf0300_6dq: add flash bootloader function via recovery

### DIFF
--- a/mf0300_6dq/recovery/recovery_updater.cpp
+++ b/mf0300_6dq/recovery/recovery_updater.cpp
@@ -445,6 +445,74 @@ Value* MoveExt4PartitionFn(const char* name, State* state, const std::vector<std
   return StringValue("t");
 }
 
+// Extract bootloader image to destination path
+// package_extract_bootloader(package_path, destination_path)
+// Usage example in releasetools.py for mf0300 device:
+// package_extract_bootloader("bootloader.img", "/dev/block/mmcblk3boot0")
+Value* PackageExtractBootloaderFn(const char* name, State* state, const std::vector<std::unique_ptr<Expr>>& argv) {
+  if (argv.size() != 2) {
+      return ErrorAbort(state, kArgsParsingFailure, "%s() expects 2 args, got %d",
+                        name, argv.size());
+  }
+  int fdm;
+  int fd_force_ro;
+  int fd_boot_config;
+  char content[2];
+  char file_force_ro[50];
+  char file_boot_config[50];
+  UpdaterInfo* ui = static_cast<UpdaterInfo*>(state->cookie);
+
+  ZipArchiveHandle za = static_cast<UpdaterInfo*>(state->cookie)->package_zip;
+  std::vector<std::string> args;
+  if (!ReadArgs(state, argv, &args)) {
+    return ErrorAbort(state, kArgsParsingFailure, "%s() Failed to parse %zu args", name,
+                      argv.size());
+  }
+  const std::string& zip_path = args[0];
+  const std::string& dest_path = args[1];
+
+  ZipEntry entry;
+  ZipString zip_string_path(zip_path.c_str());
+  if (FindEntry(za, zip_string_path, &entry) != 0) {
+      return ErrorAbort(state, kPackageExtractFileFailure, "%s(): no %s in package", name,
+                        zip_path.c_str());
+  }
+  // The partition of uboot(EMMC) is read only, So should set force_ro to 0
+  // Set boot_config to 8 which set boot0 as first boot partition.
+  strcpy(file_force_ro,"/sys/block/mmcblk3boot0/force_ro");
+  strcpy(file_boot_config,"/sys/block/mmcblk3/device/boot_config");
+  file_force_ro[17] = dest_path[17];
+  file_boot_config[17] = dest_path[17];
+  fd_force_ro = open(file_force_ro, O_RDWR);
+  fd_boot_config = open(file_boot_config, O_RDWR);
+  FILE* f = fopen(dest_path.c_str(), "wb");
+  if (f == NULL) {
+    return ErrorAbort(state, kFileOpenFailure, "%s: failed to open for write %s: %s", name, dest_path.c_str(),
+                      strerror(errno));
+  }
+  fdm = fileno(f);
+  sprintf(content, "%d", 0);
+  write(fd_force_ro, content, strlen(content));
+  // The  offset of uboot is 1K
+  lseek(fdm , 1024, SEEK_SET);
+  bool success = true;
+  int32_t ret = ExtractEntryToFile(za, &entry, fdm);
+  if (ret != 0) {
+    LOG(ERROR) << name << ": Failed to extract entry \"" << zip_path << "\" ("
+               << entry.uncompressed_length << " bytes) to \"" << dest_path
+               << "\": " << ErrorCodeString(ret);
+    success = false;
+  }
+  sprintf(content, "%d", 1);
+  write(fd_force_ro,content,strlen(content));
+  sprintf(content, "%d", 8);
+  write(fd_boot_config,content,strlen(content));
+  close(fd_force_ro);
+  close(fd_boot_config);
+  fclose(f);
+
+  return StringValue(success ? "t" : "");
+}
 
 void Register_librecovery_updater_mf0300_6dq() {
   RegisterFunction("write_partition_table", WritePartitionTableFn);
@@ -458,4 +526,5 @@ void Register_librecovery_updater_mf0300_6dq() {
   RegisterFunction("unmount_l", UnmountlFn);
   RegisterFunction("remountro", RemountReadOnlyFn);
   RegisterFunction("move_ext4_partition", MoveExt4PartitionFn);
+  RegisterFunction("package_extract_bootloader", PackageExtractBootloaderFn);
 }


### PR DESCRIPTION
Add function "package_extract_bootloader" to update bootloader.
PackageExtractBootloaderFn is used to update ext4.
    SD: /dev/block/mmcblkx  offset:1024
    emmc: /dev/block/mmcblkxboot0 offset:1024.
    emmc bootloader partition is read only by default.

You can call this function in OTA update_script via:
    package_extract_bootloader(package_path, destination_path)
For mf0300 example:
    package_extract_bootloader("bootloader.img", "/dev/block/mmcblk3boot0");