### PR TITLE
fixed few SELinux issues

### DIFF
--- a/mf0300_6dq/mf0300_6dq.mk
+++ b/mf0300_6dq/mf0300_6dq.mk
@@ -142,6 +142,7 @@ PRODUCT_PACKAGES += \
 	TeamViewerQS
 
 PRODUCT_PROPERTY_OVERRIDES += \
+    ro.build.selinux=1 \
     config.disable_cameraservice=true \
     ro.tether.denied=true \
     ro.control_privapp_permissions=enforce \

--- a/mf0300_6dq/sepolicy/init.te
+++ b/mf0300_6dq/sepolicy/init.te
@@ -1,0 +1,2 @@
+# allow init to read /proc/version
+allow init proc_version:file r_file_perms;

--- a/mf0300_6dq/sepolicy/system_app.te
+++ b/mf0300_6dq/sepolicy/system_app.te
@@ -4,3 +4,5 @@ binder_call(system_app, wificond)
 use_serialnumberservice(system_app)
 # allow system_app to read /proc/version
 allow system_app proc_version:file r_file_perms;
+# allow system_app to read files from selinuxfs
+allow system_app selinuxfs:file r_file_perms;

--- a/mf0300_6dq/sepolicy/system_app.te
+++ b/mf0300_6dq/sepolicy/system_app.te
@@ -2,3 +2,5 @@
 binder_call(system_app, wificond)
 # allow system_app to get access to serial number
 use_serialnumberservice(system_app)
+# allow system_app to read /proc/version
+allow system_app proc_version:file r_file_perms;

--- a/mf0300_6dq/sepolicy/system_server.te
+++ b/mf0300_6dq/sepolicy/system_server.te
@@ -2,3 +2,5 @@ allow system_server shift4_app:file w_file_perms;
 
 # Allow system_server to write to /proc/<pid>/timerslack_ns
 allow system_server appdomain:file w_file_perms;
+# Allow system_server to read /proc/version
+allow system_server proc_version:file r_file_perms;


### PR DESCRIPTION
```
02-26 11:54:53.820     1     1 W init    : type=1400 audit(0.0:4): avc: denied { getattr } for path="/proc/version" dev="proc" ino=4026531966 scontext=u:r:init:s0 tcontext=u:object_r:proc_version:s0 tclass=file permissive=0
02-26 11:55:35.560   403   403 W Thread-19: type=1400 audit(0.0:23): avc: denied { read } for name="version" dev="proc" ino=4026531966 scontext=u:r:system_server:s0 tcontext=u:object_r:proc_version:s0 tclass=file permissive=0
02-26 11:55:53.790   689   689 W ndroid.settings: type=1400 audit(0.0:24): avc: denied { read } for name="enforce" dev="selinuxfs" ino=4 scontext=u:r:system_app:s0 tcontext=u:object_r:selinuxfs:s0 tclass=file permissive=0
02-26 11:55:53.800   689   689 W ndroid.settings: type=1400 audit(0.0:25): avc: denied { read } for name="enforce" dev="selinuxfs" ino=4 scontext=u:r:system_app:s0 tcontext=u:object_r:selinuxfs:s0 tclass=file permissive=0
02-26 11:55:53.870   689   689 W ndroid.settings: type=1400 audit(0.0:26): avc: denied { read } for name="version" dev="proc" ino=4026531966 scontext=u:r:system_app:s0 tcontext=u:object_r:proc_version:s0 tclass=file permissive=0
```
also enabled SELinux status tile in About menu