### PR TITLE
Devices: fsl: mf0300_6dq: add media.omx support in device manifest

### DIFF
--- a/mf0300_6dq/manifest.xml
+++ b/mf0300_6dq/manifest.xml
@@ -118,4 +118,13 @@
             <instance>default</instance>
         </interface>
     </hal>
+    <hal format="hidl">
+        <name>android.hardware.media.omx</name>
+        <transport>hwbinder</transport>
+        <version>1.0</version>
+        <interface>
+            <name>IOmx</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
 </manifest>


### PR DESCRIPTION
Fix issue:

/system/bin/hwservicemanager: getTransport: Cannot find entry android.hardware.media.omx@1.0::IOmx/default in either framework or device manifest.