### PR TITLE
Devices: fsl: mf0300_6dq: map iMobile3 signature with Shift4 seinfo

### DIFF
--- a/mf0300_6dq/sepolicy/mac_permissions.xml
+++ b/mf0300_6dq/sepolicy/mac_permissions.xml
@@ -22,4 +22,9 @@
     <signer signature="@SHIFT4" >
       <seinfo value="shift4" />
     </signer>
+
+    <!-- IMobile3 signature in AOSP -->
+    <signer signature="@IMOBILE3" >
+      <seinfo value="shift4" />
+     </signer>
 </policy>


### PR DESCRIPTION
The mac_permissions.xml file is used for controlling the mmac solutions
as well as mapping a public base16 signing key with an arbitrary seinfo
string. Details of the files contents can be found in a comment at the
top of that file. The seinfo string, previously mentioned, is the same string
that is referenced in seapp_contexts.
It is important to note the final processed version of this file
is stripped of comments and whitespace. This is to preserve space on the
system.img. If one wishes to view it in a more human friendly format,
the "tidy" or "xmllint" command will assist you.