### PR TITLE
Devices: fsl: mf0300_6dq: remove SystemUI overlay

### DIFF
--- a/mf0300_6dq/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
+++ b/mf0300_6dq/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
@@ -1,4 +1,0 @@
-<resources>
-    <!-- Minimum swipe distance to catch the swipe gestures to invoke assist or switch tasks. -->
-    <dimen name="navigation_bar_min_swipe_distance">40dp</dimen>
-</resources>


### PR DESCRIPTION
Because SystemUI is going to be removed from Shift4 ROM build.