### PR TITLE
Devices: fsl: mf0300_6dq: update ota server name for userdebug

### DIFF
--- a/mf0300_6dq/etc/ota-userdebug.conf
+++ b/mf0300_6dq/etc/ota-userdebug.conf
@@ -1,2 +1,2 @@
-server=lighthouse.net
+server=droid-update.harbortouch.com
 port=8080


### PR DESCRIPTION
Set new DNS server name to droid-update.harbortouch.com for userdebug build type.