### PR TITLE
Devices: fsl: mf0300_6dq: allow to use virtual keyboard with physical

### DIFF
--- a/mf0300_6dq/overlay/frameworks/base/packages/SettingsProvider/res/values/defaults.xml
+++ b/mf0300_6dq/overlay/frameworks/base/packages/SettingsProvider/res/values/defaults.xml
@@ -23,4 +23,6 @@
     <string name="def_location_providers_allowed" translatable="false"></string>
     <bool name="def_bluetooth_on">false</bool>
     <bool name="def_stay_on_while_plugged_in">true</bool>
+    <!-- Default for Settings.Secure.SHOW_IME_WITH_HARD_KEYBOARD -->
+    <bool name="def_show_ime_with_hard_keyboard">true</bool>
 </resources>


### PR DESCRIPTION
By default Android doesn't show virtual keyboard when physical keyboard
is connected. This behaviour can be easily changed by switching just one
option in system settings.

Required by HBR application and was reported as bug.

HBR application decides itself when to show virtual keyboard and also
has similar option in settings. When Android option is set to disabled
state, HBR application can't to show virtual keyboard even its option
is set. When Android option is set to enabled state (i.e. show virtual
keyboard while physical keyboard is active), HBR application behaves
correctly, so enable this by default.