### PR TITLE
USB devices access

### DIFF
--- a/mf0300_6dq/sepolicy/shift4_app.te
+++ b/mf0300_6dq/sepolicy/shift4_app.te
@@ -47,3 +47,4 @@ allow shift4_app { accessibility_service
 
 allow shift4_app cust_display_device:chr_file rw_file_perms;
 allow shift4_app scales_device:chr_file rw_file_perms;
+allow shift4_app usb_device:chr_file rw_file_perms;

--- a/mf0300_6dq/ueventd.freescale.gpt.rc
+++ b/mf0300_6dq/ueventd.freescale.gpt.rc
@@ -19,6 +19,7 @@
 /dev/ir                   0660   system     system
 /dev/caam_kb              0660   system     system
 /dev/input/event*         0660   system     system
+/dev/bus/usb/*/*          0666   root       usb
 
 # sysfs properties
 /sys/devices/virtual/input/input*   name        0660  system   system

--- a/mf0300_6dq/ueventd.freescale.mbr.rc
+++ b/mf0300_6dq/ueventd.freescale.mbr.rc
@@ -19,6 +19,7 @@
 /dev/ir                   0660   system     system
 /dev/caam_kb              0660   system     system
 /dev/input/event*         0660   system     system
+/dev/bus/usb/*/*          0666   root       usb
 
 # sysfs properties
 /sys/devices/virtual/input/input*   name        0660  system   system


### PR DESCRIPTION
- SELinux: allow Shift4 apps access USB devices
- uevntd: set 0666 on all USB devices to allow userspaces apps to access these files

not tested (have no printer), but according to log from bugreport, this must be enough