### PR TITLE
 Devices: fsl: mf0300_6dq: update selinux policies

### DIFF
--- a/mf0300_6dq/sepolicy/platform_app.te
+++ b/mf0300_6dq/sepolicy/platform_app.te
@@ -1,2 +1,3 @@
 allow platform_app rootfs:dir r_dir_perms;
 allow platform_app proc_stat:file r_file_perms;
+allow platform_app shift4_app_data_file:dir r_dir_perms;

--- a/mf0300_6dq/sepolicy/sernd.te
+++ b/mf0300_6dq/sepolicy/sernd.te
@@ -17,4 +17,5 @@ allow sernd self:capability { net_admin net_raw };
 # allow ioctl request to change ethernet hw mac address
 allowxperm sernd self:tcp_socket ioctl SIOCSIFHWADDR;
 
+allow sernd toolbox_exec:file r_file_perms;
 allow sernd shell_exec:file rx_file_perms;

--- a/mf0300_6dq/sepolicy/sernd.te
+++ b/mf0300_6dq/sepolicy/sernd.te
@@ -11,6 +11,7 @@ allow sernd sysfs_i2c:file w_file_perms;
 
 # allow socket operations
 allow sernd self:tcp_socket create_stream_socket_perms;
+allow sernd self:udp_socket create_socket_perms;
 allow sernd self:capability { net_admin net_raw };
 
 # allow ioctl request to change ethernet hw mac address

--- a/mf0300_6dq/sepolicy/sernd.te
+++ b/mf0300_6dq/sepolicy/sernd.te
@@ -16,6 +16,7 @@ allow sernd self:capability { net_admin net_raw };
 
 # allow ioctl request to change ethernet hw mac address
 allowxperm sernd self:tcp_socket ioctl SIOCSIFHWADDR;
+allowxperm sernd self:udp_socket ioctl SIOCSIFNETMASK;
 
 allow sernd toolbox_exec:file r_file_perms;
 allow sernd shell_exec:file rx_file_perms;

--- a/mf0300_6dq/sepolicy/sernd.te
+++ b/mf0300_6dq/sepolicy/sernd.te
@@ -16,3 +16,5 @@ allow sernd self:capability { net_admin net_raw };
 
 # allow ioctl request to change ethernet hw mac address
 allowxperm sernd self:tcp_socket ioctl SIOCSIFHWADDR;
+
+allow sernd shell_exec:file rx_file_perms;

--- a/mf0300_6dq/sepolicy/shift4_app.te
+++ b/mf0300_6dq/sepolicy/shift4_app.te
@@ -15,6 +15,7 @@ use_cardreader(shift4_app)
 allow shift4_app shift4_app_data_file:dir create_dir_perms;
 allow shift4_app shift4_app_data_file: { file lnk_file } create_file_perms;
 allow shift4_app proc_version:file r_file_perms;
+allow shift4_app shell_data_file:dir r_dir_perms;
 
 allow shift4_app { accessibility_service
                    activity_service

--- a/mf0300_6dq/sepolicy/shift4_app.te
+++ b/mf0300_6dq/sepolicy/shift4_app.te
@@ -32,6 +32,7 @@ allow shift4_app { accessibility_service
                    input_service
                    jobscheduler_service
                    mediaserver_service
+                   media_session_service
                    mount_service
                    notification_service
                    power_service


### PR DESCRIPTION
Due to fsl_imx_demo changes and some shift4_app fixes as well:

- In order for systemui can access /data/data/com.harbortouch.echopro*
- Use MediaSession service to interact with media controllers, volume keys, media buttons, and transport controls
- Sernd uses ifconfig util in order to manipulate sockfs
- Sernd uses /system/bin/toybox and due to dm-0 dev Oreo new security policies we need to
specify permission via selinux as well
