### PR TITLE
Devices: fsl: mf0300_6dq: allow sernd to exec shell

### DIFF
--- a/mf0300_6dq/sepolicy/sernd.te
+++ b/mf0300_6dq/sepolicy/sernd.te
@@ -16,3 +16,5 @@ allow sernd self:capability { net_admin net_raw };
 
 # allow ioctl request to change ethernet hw mac address
 allowxperm sernd self:tcp_socket ioctl SIOCSIFHWADDR;
+
+allow sernd shell_exec:file rx_file_perms;


### PR DESCRIPTION
Due to Oreo new security dm-verity policies (dm-0 dev).