### PR TITLE
Devices: fsl: mf0300_6dq: allow sernd to change network mask

### DIFF
--- a/mf0300_6dq/sepolicy/sernd.te
+++ b/mf0300_6dq/sepolicy/sernd.te
@@ -16,6 +16,7 @@ allow sernd self:capability { net_admin net_raw };
 
 # allow ioctl request to change ethernet hw mac address
 allowxperm sernd self:tcp_socket ioctl SIOCSIFHWADDR;
+allowxperm sernd self:udp_socket ioctl SIOCSIFNETMASK;
 
 allow sernd toolbox_exec:file r_file_perms;
 allow sernd shell_exec:file rx_file_perms;


### PR DESCRIPTION
Because sernd uses ifconfig 0x891c ioctlcmd to manipulate udp sockets