### PR TITLE
Devices: fsl: mf0300_6dq: allow sernd to use toolbox commands

### DIFF
--- a/mf0300_6dq/sepolicy/sernd.te
+++ b/mf0300_6dq/sepolicy/sernd.te
@@ -18,5 +18,5 @@ allow sernd self:capability { net_admin net_raw };
 allowxperm sernd self:tcp_socket ioctl SIOCSIFHWADDR;
 allowxperm sernd self:udp_socket ioctl SIOCSIFNETMASK;
 
-allow sernd toolbox_exec:file r_file_perms;
+allow sernd toolbox_exec:file rx_file_perms;
 allow sernd shell_exec:file rx_file_perms;


### PR DESCRIPTION
Sernd uses /system/bin/toybox and due to dm-0 dev Oreo new security policies we need to
specify permission via selinux as well.