### PR TITLE
Devices: fsl: mf0300_6dq: allow egtouchd to exec shell

### DIFF
--- a/mf0300_6dq/sepolicy/egtouchd.te
+++ b/mf0300_6dq/sepolicy/egtouchd.te
@@ -8,3 +8,4 @@ binder_use(egtouchd)
 binder_call(binderservicedomain, egtouchd)
 
 allow egtouchd proc_version:file r_file_perms;
+allow egtouchd shell_exec:file rx_file_perms;


### PR DESCRIPTION
Due to audit2allow:
type=1400 audit(1558182240.230:4708): avc: denied { execute } for pid=2308 comm="eGTouchD" name="sh" dev="dm-0" ino=369 scontext=u:r:egtouchd:s0 tcontext=u:object_r:shell_exec:s0 tclass=file permissive=0