### PR TITLE
Devices: fsl: mf0300_6dq: allow egtouchd to exec toolbox

### DIFF
--- a/mf0300_6dq/sepolicy/egtouchd.te
+++ b/mf0300_6dq/sepolicy/egtouchd.te
@@ -9,3 +9,4 @@ binder_call(binderservicedomain, egtouchd)
 
 allow egtouchd proc_version:file r_file_perms;
 allow egtouchd shell_exec:file rx_file_perms;
+allow egtouchd toolbox_exec:file rx_file_perms;


### PR DESCRIPTION
Due to audit2allow:
type=1400 audit(1558184234.270:6): avc: denied { getattr } for pid=316 comm="sh" path="/system/bin/toybox" dev="dm-0" ino=407 scontext=u:r:egtouchd:s0 tcontext=u:object_r:toolbox_exec:s0 tclass=file permissive=0