### PR TITLE
Devices: fsl: mf0300_6dq: allow egtouchd to access hidraw devices

### DIFF
--- a/mf0300_6dq/sepolicy/egtouchd.te
+++ b/mf0300_6dq/sepolicy/egtouchd.te
@@ -10,3 +10,4 @@ binder_call(binderservicedomain, egtouchd)
 allow egtouchd proc_version:file r_file_perms;
 allow egtouchd shell_exec:file rx_file_perms;
 allow egtouchd toolbox_exec:file rx_file_perms;
+allow egtouchd hidraw_device:chr_file rw_file_perms;


### PR DESCRIPTION
Because Elite POS touchscreen appears as hidraw device in /dev/hidraw*.
Also cause audit2allow:
avc: denied { read write } for pid=317 comm="eGTouchD" name="hidraw0" dev="tmpfs" ino=11277 scontext=u:r:egtouchd:s0 tcontext=u:object_r:hidraw_device:s0 tclass=chr_file permissive=0