### PR TITLE
Devices: fsl: mf0300_6dq: translate system_data to egtouch_data files

### DIFF
--- a/mf0300_6dq/sepolicy/egtouchd.te
+++ b/mf0300_6dq/sepolicy/egtouchd.te
@@ -19,3 +19,4 @@ allow egtouchd egtouchd_data_file:fifo_file create_file_perms;
 allow egtouchd egtouchd_data_file:file create_file_perms;
 allow egtouchd device:dir r_dir_perms;
 allow egtouchd system_data_file:dir rw_dir_perms;
+file_type_auto_trans(egtouchd, system_data_file, egtouchd_data_file)


### PR DESCRIPTION
Translation works only within specific egtouch domain, as there is no option to mark
only stand alone files in /data dir even with the file_context configuration.
Just mark those files in /data dir as egtouch_data_file to keep all egtouch affected files
in one place, but translate them from system_data_file to egtouchd_data_file manually