### PR TITLE
Devices: fsl: mf0300_6dq: hide status bar

### DIFF
--- a/mf0300_6dq/overlay/frameworks/base/core/res/res/values/dimens.xml
+++ b/mf0300_6dq/overlay/frameworks/base/core/res/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Height of the status bar -->
+    <dimen name="status_bar_height">0dip</dimen>
+</resources>


### PR DESCRIPTION
Hide status bar by setting status bar height to 0dp